### PR TITLE
Fix sinkhorn implementation #1

### DIFF
--- a/MatrixRescaling/Sinkhorn.cpp
+++ b/MatrixRescaling/Sinkhorn.cpp
@@ -55,6 +55,69 @@ D max_(D* c, int n) {
 D _answer, _eta;
 chrono::duration<D> _time;
 int _iter;
+
+D sinkhorn_mc(int r_dim, int c_dim, D * C, D * r, D * c, D eta, D * A) {
+  	D * C0 = new D[r_dim * c_dim];
+	memcpy(C0, C, sizeof(D) * r_dim * c_dim);
+
+	auto start = chrono::high_resolution_clock::now();
+    
+	D C_max = max_(C, r_dim*c_dim);
+	cblas_daxpy (r_dim * c_dim, -1 + (1. / max(C_max, (D)0.01)), C0, 1, C, 1);	
+
+    D *Xi = new D [r_dim * c_dim];
+	exp(r_dim * c_dim, C, -eta, Xi);
+
+    D *u = new D [r_dim];
+    D *v = new D [c_dim];
+    D *row_dif = new D[r_dim];
+    D *col_dif = new D[c_dim];
+    D dist_AU;
+    int n_iter = 0;
+    memcpy(v, onec, sizeof(D) * c_dim);
+    for (; n_iter < MAX_ITER; n_iter += 2) {
+        cblas_dgemv(CblasRowMajor, CblasNoTrans, r_dim, c_dim, 1, Xi, c_dim, v, 1, 0, u, 1);
+        for (int i=0; i<r_dim; ++i) { u[i] = r[i] / u[i]; }
+        cblas_dgemv(CblasRowMajor, CblasTrans,   r_dim, c_dim, 1, Xi, c_dim, u, 1, 0, v, 1);
+        for (int j=0; j<c_dim; ++j) { v[j] = c[j] / v[j]; }
+
+        if (n_iter % 100 == 0) {
+            for (int i = 0; i < r_dim; ++i) {
+                int k = i*c_dim;
+                for (int j = 0; j < c_dim; ++j ) {
+                    A[k + j] = Xi[k + j] * u[i] * v[j];
+                }
+            }
+
+			cblas_dgemv (CblasRowMajor, CblasNoTrans, r_dim, c_dim, 1, A, c_dim, onec, 1, 0, row_dif, 1);
+			cblas_dgemv (CblasRowMajor, CblasTrans,   r_dim, c_dim, 1, A, c_dim, oner, 1, 0, col_dif, 1);
+			cblas_daxpy (r_dim, -1, r, 1, row_dif, 1);
+			cblas_daxpy (c_dim, -1, c, 1, col_dif, 1);
+			//take the l1 norm
+			dist_AU = cblas_dasum(r_dim, row_dif, 1) + cblas_dasum(c_dim, col_dif, 1);
+            // std::cout << "dist_AU: " << dist_AU << std::endl;
+            if (dist_AU < EPS) {
+                break;
+            }
+        }
+    }    
+	D cur_cost = cblas_ddot(c_dim * r_dim, C0, 1, A, 1);
+	_answer = cur_cost; _iter = n_iter;
+	auto finish = chrono::high_resolution_clock::now();
+
+	chrono::duration<D> elapsed = finish - start;
+	_time = elapsed;
+
+    delete [] u;
+    delete [] v;
+    delete [] row_dif;
+    delete [] col_dif;
+	memcpy(C, C0, sizeof(D) * r_dim * c_dim);
+    delete [] C0;
+    delete [] Xi;
+	return cur_cost;
+}
+
 D sinkhorn(int r_dim, int c_dim, D * C, D * r, D * c, D eta, D * A) {
 
   	D * C0 = new D[r_dim * c_dim];
@@ -120,14 +183,9 @@ D sinkhorn(int r_dim, int c_dim, D * C, D * r, D * c, D eta, D * A) {
 			//printf(".");
 			fflush(stdout);
 			
-			cblas_dgemv (CblasRowMajor, CblasNoTrans, r_dim, c_dim, 1, A, c_dim, onec, 1, 0, row_sum, 1);
-			cblas_dgemv (CblasRowMajor, CblasTrans, r_dim, c_dim, 1, A, c_dim, oner, 1, 0, col_sum, 1);
-			row_dif = new D[r_dim];
-			memcpy(row_dif, row_sum, sizeof(D) * r_dim);
-			//this subtracts r from row_diff
+			cblas_dgemv (CblasRowMajor, CblasNoTrans, r_dim, c_dim, 1, A, c_dim, onec, 1, 0, row_dif, 1);
+			cblas_dgemv (CblasRowMajor, CblasTrans, r_dim, c_dim, 1, A, c_dim, oner, 1, 0, col_dif, 1);
 			cblas_daxpy(r_dim, -1, r, 1, row_dif, 1);
-			col_dif = new D[c_dim];
-			memcpy(col_dif, col_sum, sizeof(D) * c_dim);
 			cblas_daxpy(c_dim, -1, c, 1, col_dif, 1);
 			//take the l1 norm
 			dist_AU = cblas_dasum(r_dim, row_dif, 1) + cblas_dasum(c_dim, col_dif, 1);
@@ -204,7 +262,8 @@ int main(int argc, char ** argv) {
 		D mid = (le + ri) / 2;
 		_eta = mid;
 		printf("Trying eta = %f\n", _eta);
-		D ans = sinkhorn(r_dim, c_dim, C, r, c, _eta, A);
+//		D ans = sinkhorn(r_dim, c_dim, C, r, c, _eta, A);
+		D ans = sinkhorn_mc(r_dim, c_dim, C, r, c, _eta, A);
 		if(abs(ans - OPT) < ACC * OPT) ri = mid;
 		else le = mid;
 		if(OPT == -1) break;

--- a/MatrixRescaling/_Run_Sinkhorn.sh
+++ b/MatrixRescaling/_Run_Sinkhorn.sh
@@ -1,4 +1,4 @@
-g++ -O3 Sinkhorn.cpp libopenblas.a -o temp -lpthread
+g++ -std=c++11 -O3 Sinkhorn.cpp libopenblas.a -o temp -lpthread
 
 echo "cifar_0"
 ./temp 61314 < ../Data/CIFAR/cifar_0.txt


### PR DESCRIPTION
Hi Yihe,

Please check out my code change. With this change, you are able to run the same Sinkhorn at 1/20 of time.

Jianbo

Before
```
cifar_0
IO done
Trying eta = 200.000000
Trying eta = 100.000000
Trying eta = 50.000000
Trying eta = 75.000000
Trying eta = 87.500000
Trying eta = 93.750000
Trying eta = 96.875000
Trying eta = 98.437500
Trying eta = 99.218750

Cost = 67472.355336
No of iterations = 348
Time taken = 1.113242
Eta = 99.218750
```
After
```
cifar_0
IO done
Trying eta = 200.000000
Trying eta = 100.000000
Trying eta = 50.000000
Trying eta = 75.000000
Trying eta = 87.500000
Trying eta = 93.750000
Trying eta = 96.875000
Trying eta = 98.437500
Trying eta = 99.218750

Cost = 67509.084906
No of iterations = 400
Time taken = 0.053563
Eta = 99.218750
```